### PR TITLE
allow for default headers to be defined in config

### DIFF
--- a/Mailer.php
+++ b/Mailer.php
@@ -87,6 +87,11 @@ class Mailer extends BaseMailer
     public $enableSwiftMailerLogging = false;
 
     /**
+     * @var array custom default headers that should be applied to all messages sent
+     */
+    public $defaultHeaders = [];
+
+    /**
      * @var \Swift_Mailer Swift mailer instance.
      */
     private $_swiftMailer;
@@ -94,7 +99,6 @@ class Mailer extends BaseMailer
      * @var \Swift_Transport|array Swift transport instance or its array configuration.
      */
     private $_transport = [];
-
 
     /**
      * @return array|\Swift_Mailer Swift mailer instance or array configuration.
@@ -245,5 +249,24 @@ class Mailer extends BaseMailer
         }
 
         return $object;
+    }
+
+    /**
+     * Add default parameters to the message while composing it.
+     * @param null $view
+     * @param array $params
+     * @return Message
+     */
+    public function compose($view = null, array $params = [])
+    {
+        /** @var Message $message */
+        $message = parent::compose($view, $params);
+
+        // add any default headers to the message
+        foreach ($this->defaultHeaders as $key => $val) {
+            $message->addHeader($key, $val);
+        }
+
+        return $message;
     }
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ return [
 ];
 ```
 
+Additional headers that should be included in each email sent can be defined as follows:
+
+```
+return [
+    //....
+    'components' => [
+        'mailer' => [
+            'class' => 'yii\swiftmailer\Mailer',
+            'defaultHeaders' => [
+                'X-MC-Subaccount' => 'subaccount'
+            ]
+        ],
+    ],
+];
+```
+
 You can then send an email as follows:
 
 ```php

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -499,4 +499,17 @@ U41eAdnQ3dDGzUNedIJkSh6Z0A4VMZIEOag9hPNYqQXZBQgfobvPKw==
         $message->setHeader('Multiple', ['value1', 'value2']);
         $this->assertEquals(['value1', 'value2'], $message->getHeader('Multiple'));
     }
+
+    public function testDefaultHeader()
+    {
+        $mailer = $this->createTestEmailComponent();
+
+        $mailer->defaultHeaders = [
+            'X-MC-Subaccount' => 'test-subaccount',
+        ];
+
+        $message = $mailer->compose();
+
+        $this->assertContains('X-MC-Subaccount: test-subaccount', $message->toString(), 'Unable to add default header!');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Allow for default headers to be defined for all messages sent.  Specifically helpful for defining a subaccount in mandrill.

