### PR TITLE
Support clone

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -44,6 +44,10 @@ class Message extends BaseMessage
      */
     private $signers = [];
 
+    public function __clone()
+    {
+        $this->_swiftMessage = clone $this->_swiftMessage;
+    }
 
     /**
      * @return \Swift_Message Swift message instance.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -140,6 +140,21 @@ class MessageTest extends TestCase
     /**
      * @depends testGetSwiftMessage
      */
+    public function testClone()
+    {
+        $m1 = new Message();
+        $m1->setFrom('user@example.com');
+        $m2 = clone $m1;
+        $m1->setTo(['user1@example.com' => 'user1']);
+        $m2->setTo(['user2@example.com' => 'user2']);
+
+        $this->assertEquals(['user1@example.com' => 'user1'], $m1->getTo());
+        $this->assertEquals(['user2@example.com' => 'user2'], $m2->getTo());
+    }
+
+    /**
+     * @depends testGetSwiftMessage
+     */
     public function testSetGet()
     {
         $message = new Message();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -140,21 +140,6 @@ class MessageTest extends TestCase
     /**
      * @depends testGetSwiftMessage
      */
-    public function testClone()
-    {
-        $m1 = new Message();
-        $m1->setFrom('user@example.com');
-        $m2 = clone $m1;
-        $m1->setTo(['user1@example.com' => 'user1']);
-        $m2->setTo(['user2@example.com' => 'user2']);
-
-        $this->assertEquals(['user1@example.com' => 'user1'], $m1->getTo());
-        $this->assertEquals(['user2@example.com' => 'user2'], $m2->getTo());
-    }
-
-    /**
-     * @depends testGetSwiftMessage
-     */
     public function testSetGet()
     {
         $message = new Message();
@@ -186,6 +171,21 @@ class MessageTest extends TestCase
         $bcc = 'bccuser@somedomain.com';
         $message->setBcc($bcc);
         $this->assertContains($bcc, array_keys($message->getBcc()), 'Unable to set bcc!');
+    }
+
+    /**
+     * @depends testSetGet
+     */
+    public function testClone()
+    {
+        $m1 = new Message();
+        $m1->setFrom('user@example.com');
+        $m2 = clone $m1;
+        $m1->setTo(['user1@example.com' => 'user1']);
+        $m2->setTo(['user2@example.com' => 'user2']);
+
+        $this->assertEquals(['user1@example.com' => 'user1'], $m1->getTo());
+        $this->assertEquals(['user2@example.com' => 'user2'], $m2->getTo());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 

I've stumbled across this issue while trying to send two very similar emails to two different addresses. I suppose this is a breaking change if someone knowingly used it as it is now, but I think that deep clone in this case is more logical and should be default in the future.