### PR TITLE
Fixes #61: yii\swiftmailer\Mailer::setTransport has no effect after sending of first message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 swiftmailer extension Change Log
 2.1.1 under development
 -----------------------
 
-- no changes in this release.
+- Bug #61: Fixed `yii\swiftmailer\Mailer::setTransport` has no effect after sending of first message (dmitry-kulikov)
 
 
 2.1.0 August 04, 2017

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -121,6 +121,7 @@ class Mailer extends BaseMailer
             throw new InvalidConfigException('"' . get_class($this) . '::transport" should be either object or array, "' . gettype($transport) . '" given.');
         }
         $this->_transport = $transport;
+        $this->_swiftMailer = null;
     }
 
     /**

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -33,10 +33,11 @@ class MailerTest extends TestCase
     public function testSetupTransport()
     {
         $mailer = new Mailer();
+        $mailer->getSwiftMailer(); // make sure accessing SwiftMailer does not affect behavior of setTransport
 
         $transport = new \Swift_SendmailTransport();
         $mailer->setTransport($transport);
-        $this->assertEquals($transport, $mailer->getTransport(), 'Unable to setup transport!');
+        $this->assertSame($transport, $mailer->getSwiftMailer()->getTransport(), 'Unable to setup transport!');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #61 
