### PR TITLE
Adds support for embedded inline attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 swiftmailer extension Change Log
 2.1.2 under development
 -----------------------
 
-- no changes in this release.
+- Added ability to specify the disposition of an attachment by supplying a `setDisposition` value when embedding content in a message
 
 
 2.1.1 April 25, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 swiftmailer extension Change Log
 2.1.2 under development
 -----------------------
 
-- Added ability to specify the disposition of an attachment by supplying a `setDisposition` value when embedding content in a message
+- Enh #63: Added ability to specify the disposition of an attachment by supplying a `setDisposition` value when embedding content in a message (CorWatts)
 
 
 2.1.1 April 25, 2018

--- a/src/Message.php
+++ b/src/Message.php
@@ -290,6 +290,9 @@ class Message extends BaseMessage
         if (!empty($options['contentType'])) {
             $attachment->setContentType($options['contentType']);
         }
+        if (!empty($options['setDisposition'])) {
+          $attachment->setDisposition($options['setDisposition']);
+        }
         $this->getSwiftMessage()->attach($attachment);
 
         return $this;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -356,13 +356,15 @@ U41eAdnQ3dDGzUNedIJkSh6Z0A4VMZIEOag9hPNYqQXZBQgfobvPKw==
         $message->setTextBody('Yii Swift Create Attachment Test body');
         $fileName = 'test.txt';
         $fileContent = 'Test attachment content';
-        $message->attachContent($fileContent, ['fileName' => $fileName]);
+        $message->attachContent($fileContent, ['fileName' => $fileName, 'contentType' => 'image/png', 'setDisposition' => 'inline']);
 
         $this->assertTrue($message->send());
 
         $attachment = $this->getAttachment($message);
         $this->assertTrue(is_object($attachment), 'No attachment found!');
         $this->assertEquals($fileName, $attachment->getFilename(), 'Invalid file name!');
+        $this->assertEquals('image/png', $attachment->getContentType(), 'Invalid content type!');
+        $this->assertEquals('inline', $attachment->getDisposition(), 'Invalid disposition!');
     }
 
     /**


### PR DESCRIPTION
Enables setting the setDisposition option when embedding an attachment.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
