### PR TITLE
Add function to get decoded message from Swiftmailer

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -429,6 +429,16 @@ class Message extends BaseMessage
     }
 
     /**
+     * Returns decoded string representation of this message.
+     * Use for testing with codeception.
+     * @return string the decoded string representation of this message.
+     */
+    public function toStringDecoded()
+    {
+        return quoted_printable_decode($this->toString());
+    }
+
+    /**
      * Creates the Swift email message instance.
      * @return \Swift_Message email message instance.
      */


### PR DESCRIPTION
for use with Codeception.

Works when the message got encoded through: Swift_Mime_ContentEncoder_NativeQpContentEncoder->encodeString() which is the case for UTF8 content.

In Unit tests instead of $mail->toString() use $mail->toStringDecoded().

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
